### PR TITLE
Fix array "double-wrapping" of datapoints for MQ traceroute

### DIFF
--- a/src/ps_collector/parsePush.py
+++ b/src/ps_collector/parsePush.py
@@ -344,14 +344,19 @@ class PSPushParser(multiprocessing.Process):
                 int(timestamp): int(throughput)
             }
 
-        else:
-            if test_type == "latencybg":
-                lost_packets = parsed_object['result']['packets-lost'] / parsed_object['result']['packets-sent']
-                to_return['datapoints'] = {
-                    int(timestamp): lost_packets
-                }
-                self._message_bus.sendParsed("perfsonar.raw.packet-loss-rate", to_return)
+        elif test_type == "latencybg":
+            lost_packets = parsed_object['result']['packets-lost'] / parsed_object['result']['packets-sent']
+            to_return['datapoints'] = {
+                int(timestamp): lost_packets
+            }
+            self._message_bus.sendParsed("perfsonar.raw.packet-loss-rate", to_return)
 
+        elif test_type == "trace":
+            to_return['datapoints'] = {
+                int(timestamp): parsed_object['result'][self.topic_map[test_type]['datapoint']][0]
+            }
+
+        else:
             # For non latency tests
             to_return['datapoints'] = {
                 int(timestamp): parsed_object['result'][self.topic_map[test_type]['datapoint']]


### PR DESCRIPTION
`datapoints` output is being returned in a nested array, which is confusing ps-ingest.

Current output format for MQ data:
```json
{
   "meta":{
      "input_source":"hcc-ps01.unl.edu",
      "input_destination":"ps2.kipt.kharkov.ua",
      "source":"129.93.183.249",
      "destination":"193.239.180.213",
      "measurement_agent":"129.93.183.249",
      "push":true
   },
   "version":2,
   "datapoints":{
      "1617725239":[
         [
            {
               "as":{
                  "owner":"NU-AS, US",
                  "number":7896
               },
               "ip":"129.93.183.254",
               "rtt":"PT0.0002S",
               "hostname":"hcc-shor-m1426-ve19.unl.edu"
            },
...
```

Expected output format:
```
{
   "meta":{
      "subject_type":"point-to-point",
      "source":"2607:f380:a4f:63::3:2",
      "destination":"2607:f8f0:660:2::3",
      "tool_name":"pscheduler/traceroute",
      "measurement_agent":"2607:f380:a4f:63::3:2",
      "input_source":"perfsonar2.ultralight.org",
      "input_destination":"ps-latency.lhcmon.triumf.ca",
      "time_duration":"68.0",
      "org_metadata_key":"6bfb510cef2b432e975cd9457b34d8b1",
      "rsv-timestamp":"1617726016.120779",
      "event-type":"packet-trace",
      "summaries":0,
      "ts_start":1617725836
   },
   "version":2,
   "datapoints":{
      "1617725836":[
         {
            "ttl":1,
            "query":1,
            "success":1,
            "ip":"2607:f380:a4f:63::1",
            "hostname":"gateway",
            "as":{
               "owner":"ULTRALIGHT, US",
               "number":32361
            },
            "rtt":0.3
         },
...
```