### PR TITLE
Correct error in parse_push() introduced in 802c4a94

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+isodate
 schedule
 pika
 prometheus_client


### PR DESCRIPTION
Ugh. There's a few more issues to solve.

After opening #6, I missed that there was some extra logic happening inside that else block for the latencybg tests: It sents a packet-loss-rate, and also sets to_return for later sending. 

There's also datapoints issues with NetworkTracerouteCollector.py yet to resolve:
- `ttl` and `query` are expected to be set
- rtt is interpreted as a float, rather than an ISO duration